### PR TITLE
Fix DuckDuckGo search tool to execute query

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,7 +17,7 @@ def test_duckduckgo_search_executes_tool(monkeypatch):
             calls['query'] = query
             return f"result for {query}"
 
-    monkeypatch.setattr(search, 'DuckDuckGoSearchRun', lambda name="search-web": DummySearch())
+    monkeypatch.setattr(search, 'DuckDuckGoSearchRun', lambda name="search-web": DummySearch(name))
 
     result = search.duckduckgo_search("python")
     assert result == "result for python"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from tools import search
+
+
+def test_duckduckgo_search_executes_tool(monkeypatch):
+    calls = {}
+
+    class DummySearch:
+        def __init__(self, name=None):
+            pass
+
+        def run(self, query):
+            calls['query'] = query
+            return f"result for {query}"
+
+    monkeypatch.setattr(search, 'DuckDuckGoSearchRun', lambda name="search-web": DummySearch())
+
+    result = search.duckduckgo_search("python")
+    assert result == "result for python"
+    assert calls['query'] == "python"
+
+

--- a/tools/search.py
+++ b/tools/search.py
@@ -10,8 +10,9 @@ load_dotenv()
 
 
 def duckduckgo_search(query: str) -> str:
-    """Search the web using DuckDuckGo search API"""
-    return  DuckDuckGoSearchRun(name="search-web")
+    """Search the web using DuckDuckGo search API."""
+    search_tool = DuckDuckGoSearchRun(name="search-web")
+    return search_tool.run(query)
 
 def exa_search(query: str) -> str:
     """Search the web using Exa search API"""


### PR DESCRIPTION
## Summary
- ensure `duckduckgo_search` uses the DuckDuckGo tool to run queries and return results
- add unit test to verify that the search tool executes and returns query results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895553f62c0832c942b7e9722f00aea