### PR TITLE
Handle missing EXA API key and errors in search

### DIFF
--- a/tools/search.py
+++ b/tools/search.py
@@ -28,7 +28,7 @@ def exa_search(query: str) -> str:
             text_contents_options=True,
             highlights=True,
         )
-    except Exception as exc:  # pragma: no cover - network errors
+    except requests.exceptions.RequestException as exc:  # pragma: no cover - network errors
         return f"Exa search failed: {exc}"
 
     if not search_results:

--- a/tools/search.py
+++ b/tools/search.py
@@ -43,7 +43,10 @@ def exa_search(query: str) -> str:
                 snippet = " ".join(item["highlights"])
             elif item.get("text"):
                 snippet = item["text"]
-            formatted.append(f"{url}: {snippet}".strip())
+            if url:
+                formatted.append(f"{url}: {snippet}".strip())
+            else:
+                formatted.append(snippet.strip())
         return "\n".join(formatted)
 
     return str(search_results)

--- a/tools/search.py
+++ b/tools/search.py
@@ -11,17 +11,39 @@ load_dotenv()
 
 def duckduckgo_search(query: str) -> str:
     """Search the web using DuckDuckGo search API"""
-    return  DuckDuckGoSearchRun(name="search-web")
+    return DuckDuckGoSearchRun(name="search-web")
+
 
 def exa_search(query: str) -> str:
     """Search the web using Exa search API"""
-    search_tool = ExaSearchResults(exa_api_key=os.environ["EXA_API_KEY"])
+    api_key = os.getenv("EXA_API_KEY")
+    if not api_key:
+        return "EXA API key not found. Set EXA_API_KEY environment variable."
 
-    search_results = search_tool._run(
-    query=query,
-    num_results=5,
-    text_contents_options=True,
-    highlights=True,
-    )
+    try:
+        search_tool = ExaSearchResults(exa_api_key=api_key)
+        search_results = search_tool._run(
+            query=query,
+            num_results=5,
+            text_contents_options=True,
+            highlights=True,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        return f"Exa search failed: {exc}"
 
-    return search_results
+    if not search_results:
+        return "No search results found."
+
+    if isinstance(search_results, list):
+        formatted = []
+        for item in search_results:
+            url = item.get("url", "")
+            snippet = ""
+            if item.get("highlights"):
+                snippet = " ".join(item["highlights"])
+            elif item.get("text"):
+                snippet = item["text"]
+            formatted.append(f"{url}: {snippet}".strip())
+        return "\n".join(formatted)
+
+    return str(search_results)


### PR DESCRIPTION
## Summary
- handle missing `EXA_API_KEY` with helpful message
- wrap Exa search call in try/except and format results for readability

## Testing
- `python -m py_compile tools/search.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68955625ec1c832c97d19ed49e859de7