### PR TITLE
Add configurable LLM provider with OpenRouter auto-detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Select LLM provider: openrouter, openai, or anthropic
+LLM_PROVIDER=openrouter
+
+# API keys for providers (set the one for your chosen provider)
+#OPENROUTER_API_KEY=your_openrouter_key
+#OPENAI_API_KEY=your_openai_key
+#ANTHROPIC_API_KEY=your_anthropic_key
+
+# Optional: override default model
+#LLM_MODEL=qwen/qwen3-coder:free

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ env/
 # Environment Variables
 .env
 .env.*
+!.env.example
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ This repository is the hands-on starting point for the **AI Agents for Fun & Pro
 ```bash
 # Clone or download the starter kit, then:
 make bootstrap        # create virtual-env and install dependencies
-cp .env.example .env  # add your OpenRouter API key
+cp .env.example .env  # choose provider and add API key
 python agent.py       # run the console agent
 ```
+
+### LLM configuration
+
+Set `LLM_PROVIDER` to `openrouter`, `openai`, or `anthropic` and supply the matching API key:
+
+- `OPENROUTER_API_KEY` for OpenRouter (auto-detected if the key starts with `sk-or-` or `org-`)
+- `OPENAI_API_KEY` for OpenAI
+- `ANTHROPIC_API_KEY` for Anthropic
+
+If `LLM_PROVIDER` is not set, the application tries to detect OpenRouter keys and otherwise defaults to OpenAI. You can also override the model with `LLM_MODEL`.
 
 ## 🎉 New: Streamlit Frontend
 
@@ -54,7 +64,7 @@ make docker-run       # available at http://localhost:8000
 
 ## Architecture
 
-- **Backend**: FastAPI + LangGraph + OpenRouter
+- **Backend**: FastAPI + LangGraph + pluggable LLM provider
 - **Frontend**: Streamlit with real-time chat
 - **Agent**: ReAct pattern with tool calling
 - **Memory**: Persistent conversation history

--- a/agent.py
+++ b/agent.py
@@ -3,26 +3,27 @@ You'll extend this in later labs.
 """
 import os
 from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
+from llm.config import get_llm
 from tools.search import exa_search
 from tools.add import add_function
 
 # Load environment variables from .env file
 load_dotenv()
 
+
 def create_agent():
-    llm = ChatOpenAI(model_name="qwen/qwen3-coder:free", temperature=0, base_url="https://openrouter.ai/api/v1")
-    
+    llm = get_llm()
+
     checkpointer = MemorySaver()
 
     tools = [add_function, exa_search]  # You'll register a search tool in Lab 2
-    
+
     # Create ReAct agent with LangGraph
     agent = create_react_agent(llm, tools, checkpointer=checkpointer, verbose=True)
-    
+
     return agent
 
 if __name__ == "__main__":

--- a/llm/config.py
+++ b/llm/config.py
@@ -1,0 +1,57 @@
+import os
+from typing import Optional
+
+from langchain_openai import ChatOpenAI
+
+try:
+    from langchain_anthropic import ChatAnthropic
+except ImportError:  # pragma: no cover - Anthropic optional
+    ChatAnthropic = None
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1"
+
+
+def _detect_openrouter_from_key(key: str) -> bool:
+    """Return True if the key appears to be an OpenRouter key."""
+    return key.startswith("sk-or-") or key.startswith("org-")
+
+
+def _select_provider() -> str:
+    """Determine the LLM provider based on env vars and key format."""
+    provider = os.getenv("LLM_PROVIDER", "").strip().lower()
+    openai_key = os.getenv("OPENAI_API_KEY", "")
+    openrouter_key = os.getenv("OPENROUTER_API_KEY", "")
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY", "")
+
+    if provider:
+        return provider
+
+    if openrouter_key or _detect_openrouter_from_key(openai_key):
+        return "openrouter"
+    if anthropic_key:
+        return "anthropic"
+    return "openai"
+
+
+def get_llm():
+    """Instantiate an LLM client based on configuration."""
+    provider = _select_provider()
+    default_models = {
+        "openrouter": "qwen/qwen3-coder:free",
+        "openai": "gpt-4o-mini",
+        "anthropic": "claude-3-haiku-20240307",
+    }
+    model_name = os.getenv("LLM_MODEL", default_models.get(provider))
+
+    if provider == "openrouter":
+        api_key = os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
+        return ChatOpenAI(model_name=model_name, temperature=0, base_url=OPENROUTER_URL, api_key=api_key)
+    if provider == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        return ChatOpenAI(model_name=model_name, temperature=0, api_key=api_key)
+    if provider == "anthropic":
+        if ChatAnthropic is None:
+            raise ImportError("langchain-anthropic is required for Anthropic provider")
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        return ChatAnthropic(model_name=model_name, temperature=0, api_key=api_key)
+    raise ValueError(f"Unsupported LLM_PROVIDER '{provider}'")

--- a/llm/config.py
+++ b/llm/config.py
@@ -44,7 +44,9 @@ def get_llm():
     model_name = os.getenv("LLM_MODEL", default_models.get(provider))
 
     if provider == "openrouter":
-        api_key = os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
+        api_key = os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY must be set when provider is 'openrouter'")
         return ChatOpenAI(model_name=model_name, temperature=0, base_url=OPENROUTER_URL, api_key=api_key)
     if provider == "openai":
         api_key = os.getenv("OPENAI_API_KEY")

--- a/llm/config.py
+++ b/llm/config.py
@@ -34,7 +34,16 @@ def _select_provider() -> str:
 
 
 def get_llm():
-    """Instantiate an LLM client based on configuration."""
+    """
+    Instantiate an LLM client based on configuration.
+
+    Returns:
+        An instance of ChatOpenAI or ChatAnthropic, depending on the selected provider.
+
+    Raises:
+        ImportError: If the provider is 'anthropic' and langchain-anthropic is not installed.
+        ValueError: If the provider is unsupported.
+    """
     provider = _select_provider()
     default_models = {
         "openrouter": "qwen/qwen3-coder:free",

--- a/llm/config.py
+++ b/llm/config.py
@@ -13,7 +13,7 @@ OPENROUTER_URL = "https://openrouter.ai/api/v1"
 
 def _detect_openrouter_from_key(key: str) -> bool:
     """Return True if the key appears to be an OpenRouter key."""
-    return key.startswith("sk-or-") or key.startswith("org-")
+    return key.startswith("sk-or-v1-")
 
 
 def _select_provider() -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 langchain>=0.2.0
 langchain-community>=0.0.1
 langchain-openai
+langchain-anthropic
 langchain-exa
 langgraph
 fastapi


### PR DESCRIPTION
## Summary
- support selecting LLM provider via `LLM_PROVIDER` env var
- auto-detect OpenRouter keys and set base URL only when needed
- document provider setup and add example `.env`

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement langchain-anthropic)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689559907d98832ca22f33f0235f0845