### PR TITLE
docs: clarify local and docker startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ make frontend         # Start Streamlit frontend only
 
 ```bash
 make docker-build
-make docker-run       # available at http://localhost:8000
+make docker-run       # FastAPI server at http://localhost:8000
+```
+
+To run both the API and Streamlit frontend, use Docker Compose:
+
+```bash
+docker compose up --build  # http://localhost:8000 (API) and http://localhost:8501 (UI)
 ```
 
 ## Workshop Labs


### PR DESCRIPTION
## Summary
- document make `docker-run` output and add docker compose instructions for API and UI

## Testing
- `make bootstrap` *(fails: Could not find a version that satisfies the requirement langchain>=0.2.0)*
- `python agent.py` *(fails: ValueError: OPENROUTER_API_KEY must be set when provider is 'openrouter')*
- `make serve` *(fails: .venv/bin/uvicorn: No such file or directory)*
- `make docker-build` *(fails: docker: No such file or directory)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895c65dedbc832ca01b5696eb2f8ff4